### PR TITLE
Option to create Nuxt path using `story.path` if set

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
       contentTypes: 'YOUR_CONTENT_TYPES_NUXT_SHOULD_GENERATE_ROUTES_FOR', // optional
       resolveLinks: 'url', // optional
       resolveRelations: 'page.author', // optional
-      exclude: [] // optional
+      exclude: [], // optional
+      routeRealPath: true // optional
     }],
   ]
 }
@@ -54,6 +55,15 @@ Provide the component name and the field key as comma separated string. The limi
 
 It accepts an array of string and will prevent generation of routes matching them.
 
+#### `routeRealPath`
+
+Boolean, default `false`
+
+If `true`, Nuxt routes will be generated using the Stories `Real Path` configuration, instead of the default path.
+This can be useful for example to generate a Story with path of `/` instead of `/home`.
+
+See https://www.storyblok.com/cl/real-path-added-to-content-delivery-api
+
 ## Usage
 
 ### nuxt.config.js
@@ -67,7 +77,8 @@ export default {
       contentTypes: 'page,news',
       resolveLinks: 'url',
       resolveRelations: 'page.author',
-      exclude: [ '^\/admin' ] 
+      exclude: [ '^\/admin' ] ,
+      routeRealPath: true
     }]
   ],
   generate: {

--- a/lib/Storyblok.js
+++ b/lib/Storyblok.js
@@ -12,6 +12,7 @@ class Storyblok {
     this.resolveLinks = options.resolveLinks
     this.resolveRelations = options.resolveRelations
     this.exclude = options.exclude
+    this.routeRealPath = options.routeRealPath
     this.params = {}
   }
 
@@ -69,7 +70,7 @@ class Storyblok {
 
     let routes = stories.map((story) => {
       const lang = (story.lang === 'default' && this.defaultLanguage) ? `/${this.defaultLanguage}` : ''
-      const slug = removeTrailingSlash(story.full_slug)
+      const slug = removeTrailingSlash((this.routeRealPath && story.path) ? story.path : story.full_slug)
 
       return {
         route: `${lang}/${slug}`,


### PR DESCRIPTION
If option or real path not set, falls back to current `store.full_slug` default path.

Reason : Allows routing to (optionally) be set by the Storyblok 'real path' (found in the Story 'configuration' menu). Most useful for this is setting a real path of `/` instead of `/home`.
